### PR TITLE
Add support for IAM access key resource level restriction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/exoscale/vault-plugin-secrets-exoscale
 go 1.16
 
 require (
-	github.com/exoscale/egoscale v0.82.0
+	github.com/exoscale/egoscale v0.83.0
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch/v5 v5.5.0 h1:bAmFiUJ+o0o2B4OiTFeE3MqCOtyo+jjPP9iZ0VRxYUc=
 github.com/evanphx/json-patch/v5 v5.5.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/exoscale/egoscale v0.82.0 h1:BRJfbkvaO+OEGnzh7r3Mkx1aQ1kzJBHZJj54/DYpGxc=
-github.com/exoscale/egoscale v0.82.0/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
+github.com/exoscale/egoscale v0.83.0 h1:mo+eKegti0ALe6bHYfdeDb74w89tjcBPOTYn2rQ+Iss=
+github.com/exoscale/egoscale v0.83.0/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -627,6 +627,32 @@ type DbaasBackupConfig struct {
 	RecoveryMode *string `json:"recovery-mode,omitempty"`
 }
 
+// DbaasIntegration defines model for dbaas-integration.
+type DbaasIntegration struct {
+	// The description of the destination service types.
+	DestDescription *string `json:"dest-description,omitempty"`
+
+	// A list of the destination service types the integration supports.
+	DestServiceTypes *[]string `json:"dest-service-types,omitempty"`
+
+	// A JSON schema of additional settings of the integration.
+	Settings *struct {
+		AdditionalProperties *bool                   `json:"additionalProperties,omitempty"`
+		Properties           *map[string]interface{} `json:"properties,omitempty"`
+		Title                *string                 `json:"title,omitempty"`
+		Type                 *string                 `json:"type,omitempty"`
+	} `json:"settings,omitempty"`
+
+	// The description of the source service types.
+	SourceDescription *string `json:"source-description,omitempty"`
+
+	// A list of the source service types the integration supports.
+	SourceServiceTypes *[]string `json:"source-service-types,omitempty"`
+
+	// The type of the integration.
+	Type *string `json:"type,omitempty"`
+}
+
 // Automatic maintenance settings
 type DbaasNodeState struct {
 	// Name of the service node
@@ -1086,8 +1112,10 @@ type DbaasServicePg struct {
 
 	// PG connection information properties
 	ConnectionInfo *struct {
-		Params  *[]map[string]interface{} `json:"params,omitempty"`
-		Standby *[]map[string]interface{} `json:"standby,omitempty"`
+		Params *[]struct {
+			AdditionalProperties map[string]string `json:"-"`
+		} `json:"params,omitempty"`
+		Standby *[]string                 `json:"standby,omitempty"`
 		Syncing *[]map[string]interface{} `json:"syncing,omitempty"`
 		Uri     *[]string                 `json:"uri,omitempty"`
 	} `json:"connection-info,omitempty"`
@@ -1607,6 +1635,9 @@ type InstanceType struct {
 
 	// Instance type size
 	Size *InstanceTypeSize `json:"size,omitempty"`
+
+	// Instance Type available zones
+	Zones *[]ZoneName `json:"zones,omitempty"`
 }
 
 // Instance type family
@@ -2160,11 +2191,10 @@ type TemplateVisibility string
 
 // Zone
 type Zone struct {
-	// Zone short name
 	Name *ZoneName `json:"name,omitempty"`
 }
 
-// Zone short name
+// ZoneName defines model for zone-name.
 type ZoneName string
 
 // CreateAccessKeyJSONBody defines parameters for CreateAccessKey.
@@ -2232,9 +2262,6 @@ type CreateDbaasServiceKafkaJSONBody struct {
 	// Subscription plan
 	Plan string `json:"plan"`
 
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
-
 	// Enable Schema-Registry service
 	SchemaRegistryEnabled *bool `json:"schema-registry-enabled,omitempty"`
 
@@ -2292,9 +2319,6 @@ type UpdateDbaasServiceKafkaJSONBody struct {
 	// Subscription plan
 	Plan *string `json:"plan,omitempty"`
 
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
-
 	// Enable Schema-Registry service
 	SchemaRegistryEnabled *bool `json:"schema-registry-enabled,omitempty"`
 
@@ -2348,9 +2372,6 @@ type CreateDbaasServiceMysqlJSONBody struct {
 	// Subscription plan
 	Plan string `json:"plan"`
 
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
-
 	// ISO time of a backup to recover from for services that support arbitrary times
 	RecoveryBackupTime *string `json:"recovery-backup-time,omitempty"`
 
@@ -2397,9 +2418,6 @@ type UpdateDbaasServiceMysqlJSONBody struct {
 
 	// Subscription plan
 	Plan *string `json:"plan,omitempty"`
-
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
 
 	// Service is protected against termination and powering off
 	TerminationProtection *bool `json:"termination-protection,omitempty"`
@@ -2450,9 +2468,6 @@ type CreateDbaasServicePgJSONBody struct {
 
 	// Subscription plan
 	Plan string `json:"plan"`
-
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
 
 	// ISO time of a backup to recover from for services that support arbitrary times
 	RecoveryBackupTime *string `json:"recovery-backup-time,omitempty"`
@@ -2515,9 +2530,6 @@ type UpdateDbaasServicePgJSONBody struct {
 	// Subscription plan
 	Plan *string `json:"plan,omitempty"`
 
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
-
 	// Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the shared_buffers configuration value.
 	SharedBuffersPercentage *int64                        `json:"shared-buffers-percentage,omitempty"`
 	SynchronousReplication  *EnumPgSynchronousReplication `json:"synchronous-replication,omitempty"`
@@ -2558,9 +2570,6 @@ type CreateDbaasServiceRedisJSONBody struct {
 	// Subscription plan
 	Plan string `json:"plan"`
 
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
-
 	// Name of a backup to recover from for services that support backup names
 	RecoveryBackupName *string `json:"recovery-backup-name,omitempty"`
 
@@ -2593,9 +2602,6 @@ type UpdateDbaasServiceRedisJSONBody struct {
 
 	// Subscription plan
 	Plan *string `json:"plan,omitempty"`
-
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
 
 	// Redis.conf settings
 	RedisSettings *map[string]interface{} `json:"redis-settings,omitempty"`
@@ -2656,9 +2662,6 @@ type UpdateDbaasServiceJSONBody struct {
 
 	// Subscription plan
 	Plan *string `json:"plan,omitempty"`
-
-	// Power-on the service (true) or power-off (false)
-	Powered *bool `json:"powered,omitempty"`
 
 	// Service is protected against termination and powering off
 	TerminationProtection *bool `json:"termination-protection,omitempty"`
@@ -3755,6 +3758,12 @@ type ClientInterface interface {
 	// GetDbaasCaCertificate request
 	GetDbaasCaCertificate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListDbaasIntegrationSettings request
+	ListDbaasIntegrationSettings(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListDbaasIntegrationTypes request
+	ListDbaasIntegrationTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetDbaasServiceKafka request
 	GetDbaasServiceKafka(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4401,6 +4410,30 @@ func (c *Client) GetAntiAffinityGroup(ctx context.Context, id string, reqEditors
 
 func (c *Client) GetDbaasCaCertificate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetDbaasCaCertificateRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListDbaasIntegrationSettings(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDbaasIntegrationSettingsRequest(c.Server, integrationType, sourceType, destType)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListDbaasIntegrationTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDbaasIntegrationTypesRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -6953,6 +6986,81 @@ func NewGetDbaasCaCertificateRequest(server string) (*http.Request, error) {
 	}
 
 	operationPath := fmt.Sprintf("/dbaas-ca-certificate")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListDbaasIntegrationSettingsRequest generates requests for ListDbaasIntegrationSettings
+func NewListDbaasIntegrationSettingsRequest(server string, integrationType string, sourceType string, destType string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "integration-type", runtime.ParamLocationPath, integrationType)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "source-type", runtime.ParamLocationPath, sourceType)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithLocation("simple", false, "dest-type", runtime.ParamLocationPath, destType)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration-settings/%s/%s/%s", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListDbaasIntegrationTypesRequest generates requests for ListDbaasIntegrationTypes
+func NewListDbaasIntegrationTypesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration-types")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -12257,6 +12365,12 @@ type ClientWithResponsesInterface interface {
 	// GetDbaasCaCertificate request
 	GetDbaasCaCertificateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetDbaasCaCertificateResponse, error)
 
+	// ListDbaasIntegrationSettings request
+	ListDbaasIntegrationSettingsWithResponse(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationSettingsResponse, error)
+
+	// ListDbaasIntegrationTypes request
+	ListDbaasIntegrationTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationTypesResponse, error)
+
 	// GetDbaasServiceKafka request
 	GetDbaasServiceKafkaWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*GetDbaasServiceKafkaResponse, error)
 
@@ -13003,6 +13117,60 @@ func (r GetDbaasCaCertificateResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetDbaasCaCertificateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListDbaasIntegrationSettingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// The JSON schema representing the settings for the given integration type, source, and destination service types.
+		Settings *struct {
+			AdditionalProperties *bool                   `json:"additionalProperties,omitempty"`
+			Properties           *map[string]interface{} `json:"properties,omitempty"`
+			Title                *string                 `json:"title,omitempty"`
+			Type                 *string                 `json:"type,omitempty"`
+		} `json:"settings,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListDbaasIntegrationSettingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListDbaasIntegrationSettingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListDbaasIntegrationTypesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		DbaasIntegrations *[]DbaasIntegration `json:"dbaas-integrations,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListDbaasIntegrationTypesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListDbaasIntegrationTypesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -16138,6 +16306,24 @@ func (c *ClientWithResponses) GetDbaasCaCertificateWithResponse(ctx context.Cont
 	return ParseGetDbaasCaCertificateResponse(rsp)
 }
 
+// ListDbaasIntegrationSettingsWithResponse request returning *ListDbaasIntegrationSettingsResponse
+func (c *ClientWithResponses) ListDbaasIntegrationSettingsWithResponse(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationSettingsResponse, error) {
+	rsp, err := c.ListDbaasIntegrationSettings(ctx, integrationType, sourceType, destType, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListDbaasIntegrationSettingsResponse(rsp)
+}
+
+// ListDbaasIntegrationTypesWithResponse request returning *ListDbaasIntegrationTypesResponse
+func (c *ClientWithResponses) ListDbaasIntegrationTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationTypesResponse, error) {
+	rsp, err := c.ListDbaasIntegrationTypes(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListDbaasIntegrationTypesResponse(rsp)
+}
+
 // GetDbaasServiceKafkaWithResponse request returning *GetDbaasServiceKafkaResponse
 func (c *ClientWithResponses) GetDbaasServiceKafkaWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*GetDbaasServiceKafkaResponse, error) {
 	rsp, err := c.GetDbaasServiceKafka(ctx, name, reqEditors...)
@@ -18026,6 +18212,68 @@ func ParseGetDbaasCaCertificateResponse(rsp *http.Response) (*GetDbaasCaCertific
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Certificate *string `json:"certificate,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListDbaasIntegrationSettingsResponse parses an HTTP response from a ListDbaasIntegrationSettingsWithResponse call
+func ParseListDbaasIntegrationSettingsResponse(rsp *http.Response) (*ListDbaasIntegrationSettingsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListDbaasIntegrationSettingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// The JSON schema representing the settings for the given integration type, source, and destination service types.
+			Settings *struct {
+				AdditionalProperties *bool                   `json:"additionalProperties,omitempty"`
+				Properties           *map[string]interface{} `json:"properties,omitempty"`
+				Title                *string                 `json:"title,omitempty"`
+				Type                 *string                 `json:"type,omitempty"`
+			} `json:"settings,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListDbaasIntegrationTypesResponse parses an HTTP response from a ListDbaasIntegrationTypesWithResponse call
+func ParseListDbaasIntegrationTypesResponse(rsp *http.Response) (*ListDbaasIntegrationTypesResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListDbaasIntegrationTypesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			DbaasIntegrations *[]DbaasIntegration `json:"dbaas-integrations,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.82.0"
+const Version = "0.83.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/deepmap/oapi-codegen/pkg/runtime
 github.com/deepmap/oapi-codegen/pkg/types
 # github.com/evanphx/json-patch/v5 v5.5.0
 github.com/evanphx/json-patch/v5
-# github.com/exoscale/egoscale v0.82.0
+# github.com/exoscale/egoscale v0.83.0
 ## explicit
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api


### PR DESCRIPTION
This change introduces a new `resources` parameter to the Exoscale
secrets backend role configuration, enabling operators to create roles
issuing Exoscale IAM access keys restricted to specific resources.