### PR TITLE
Honor api_environment backend configuration property

### DIFF
--- a/path_apikey.go
+++ b/path_apikey.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -110,7 +111,7 @@ func (b *exoscaleBackend) createAPIKey(
 	}
 
 	iamAPIKey, err := b.exo.CreateIAMAccessKey(
-		ctx,
+		exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(config.APIEnvironment, config.Zone)),
 		config.Zone,
 		fmt.Sprintf("vault-%s-%s-%d", roleName, req.DisplayName, time.Now().UnixNano()),
 		opts...,

--- a/secret_apikey.go
+++ b/secret_apikey.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -75,7 +76,11 @@ func (b *exoscaleBackend) secretAPIKeyRevoke(
 	}
 	key := k.(string)
 
-	if err = b.exo.RevokeIAMAccessKey(ctx, config.Zone, &egoscale.IAMAccessKey{Key: &key}); err != nil {
+	if err = b.exo.RevokeIAMAccessKey(
+		exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(config.APIEnvironment, config.Zone)),
+		config.Zone,
+		&egoscale.IAMAccessKey{Key: &key},
+	); err != nil {
 		return nil, fmt.Errorf("unable to revoke the API key: %w", err)
 	}
 


### PR DESCRIPTION
This change fixes a bug where the backend config `APIEnvironment`
property was not actually used.