### PR TITLE
Use ttl and max_ttl from the role when renewing a lease

### DIFF
--- a/path_apikey.go
+++ b/path_apikey.go
@@ -129,6 +129,7 @@ func (b *exoscaleBackend) createAPIKey(
 		// Information for internal use (e.g. to revoke the key later on)
 		map[string]interface{}{
 			apiKeySecretDataAPIKey: *iamAPIKey.Key,
+			"role":                 roleName,
 		})
 	res.Secret.TTL = lc.TTL
 	res.Secret.MaxTTL = lc.MaxTTL


### PR DESCRIPTION
When the plugin renews the lease, it should take the ttl and max_ttl from the configuration of the role (if defined).