### PR TITLE
Use framework.CalculateTTL to calculate new TTL during lease renewal

### DIFF
--- a/secret_apikey.go
+++ b/secret_apikey.go
@@ -66,8 +66,13 @@ func (b *exoscaleBackend) secretAPIKeyRenew(
 		lc = role.LeaseConfig
 	}
 
+	ttl, _, err := framework.CalculateTTL(b.System(), req.Secret.Increment, role.LeaseConfig.TTL, 0, role.LeaseConfig.MaxTTL, 0, req.Secret.IssueTime)
+	if err != nil {
+		return nil, err
+	}
+
 	res := &logical.Response{Secret: req.Secret}
-	res.Secret.TTL = lc.TTL
+	res.Secret.TTL = ttl
 	res.Secret.MaxTTL = lc.MaxTTL
 
 	return res, nil


### PR DESCRIPTION
When vault-agent tries to renew a lease, the new `ttl` may exceed `max_ttl`. This creates this warning.  

```
[WARN] vault.read(**redacted**): TTL of "1h" exceeded the effective max_ttl of "51m37s"; TTL value is capped accordingly
[WARN] vault.read(**redacted**): TTL of "1h" exceeded the effective max_ttl of "13m49s"; TTL value is capped accordingly
```

According to Vault docs:
> The requested increment is completely advisory. The backend in charge of the secret can choose to completely ignore it. For most secrets, the backend does its best to respect the increment, but often limits it to ensure renewals every so often.

So we will use `framework.CalculateTTL` to calculate the correct `ttl` to renew the lease, automatically capping to not exceed `max_ttl`.