### PR TITLE
Stop renewing if the TTL is capped by MaxTTL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.17'
+        go-version: '^1.18'
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42
+        version: v1.45.2
     - name: Tests
       run: |
         git submodule update --init --recursive go.mk

--- a/path_apikey.go
+++ b/path_apikey.go
@@ -131,10 +131,18 @@ func (b *exoscaleBackend) createAPIKey(
 			apiKeySecretDataAPIKey: *iamAPIKey.Key,
 			"role":                 roleName,
 			"expireTime":           time.Now().Add(lc.TTL),
+			"name":                 *iamAPIKey.Name,
 		})
 
 	res.Secret.TTL = lc.TTL
 	res.Secret.MaxTTL = lc.MaxTTL
+
+	b.Logger().Info("Creating IAM secret",
+		"ttl", fmt.Sprint(lc.TTL),
+		"max_ttl", fmt.Sprint(lc.MaxTTL),
+		"role", roleName,
+		"iam_key", *iamAPIKey.Key,
+		"iam_name", *iamAPIKey.Name)
 
 	return res, nil
 }

--- a/path_apikey.go
+++ b/path_apikey.go
@@ -130,7 +130,9 @@ func (b *exoscaleBackend) createAPIKey(
 		map[string]interface{}{
 			apiKeySecretDataAPIKey: *iamAPIKey.Key,
 			"role":                 roleName,
+			"expireTime":           time.Now().Add(lc.TTL),
 		})
+
 	res.Secret.TTL = lc.TTL
 	res.Secret.MaxTTL = lc.MaxTTL
 

--- a/secret_apikey.go
+++ b/secret_apikey.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -54,21 +55,60 @@ func (b *exoscaleBackend) secretAPIKeyRenew(
 		return logical.ErrorResponse(fmt.Sprintf("role %q not found", roleName)), nil
 	}
 
-	lc, err := b.leaseConfig(ctx, req.Storage)
-	if err != nil {
-		return nil, err
-	}
-	if lc == nil {
-		lc = new(leaseConfig)
-	}
+	var leaseCfg leaseConfig
 
 	if role.LeaseConfig != nil {
-		lc = role.LeaseConfig
+		leaseCfg = *role.LeaseConfig
+	} else {
+		lc, err := b.leaseConfig(ctx, req.Storage)
+		if err != nil {
+			return nil, err
+		}
+
+		if lc != nil {
+			leaseCfg = *lc
+		}
 	}
 
 	res := &logical.Response{Secret: req.Secret}
-	res.Secret.TTL = lc.TTL
-	res.Secret.MaxTTL = lc.MaxTTL
+	res.Secret.MaxTTL = leaseCfg.MaxTTL
+
+	ttl, _, err := framework.CalculateTTL(b.System(), 0, leaseCfg.TTL, 0, 0, leaseCfg.MaxTTL, req.Secret.IssueTime)
+	if err != nil {
+		return nil, err
+	}
+
+	// Vault agent calculates a grace period of 10 to 20% of the lease TTL,
+	// once we enter the grace period, the agent stops renewing the lease
+	// and fetches a new one. This gives the workload time to complete
+	// ongoing operations before loading the new secret.
+
+	// After each renew, if the lease was extended, vault agent will recalculate
+	// the grace period based on the new TTL. If the new TTL is above the Max TTL,
+	// the value is capped, reducing the grace period to an unpredictable amount
+	// of time.
+
+	// To make sure it will calulate the refresh grace period based
+	// on a full TTL value, we extend the lease only if the TTL is
+	// not capped by max_ttl
+	if ttl == leaseCfg.TTL {
+		res.Secret.TTL = ttl
+		res.Secret.InternalData["expireTime"] = time.Now().Add(res.Secret.TTL)
+		b.Logger().Debug("Renewing", "ttl", fmt.Sprint(res.Secret.TTL), "role", roleName)
+	} else {
+		rawExpireTime, ok := req.Secret.InternalData["expireTime"]
+		if !ok {
+			return nil, fmt.Errorf("expireTime missing from secret's InternalData")
+		}
+
+		expireTime, err := time.Parse(time.RFC3339, rawExpireTime.(string))
+		if err != nil {
+			return nil, fmt.Errorf("can't parse expireTime from secret's InternalData")
+		}
+
+		res.Secret.TTL = time.Until(expireTime)
+		b.Logger().Debug("Not renewing because ttl would be capped by max_ttl ", "ttl", fmt.Sprint(res.Secret.TTL), "capped_ttl", fmt.Sprint(ttl), "role", roleName)
+	}
 
 	return res, nil
 }
@@ -93,13 +133,12 @@ func (b *exoscaleBackend) secretAPIKeyRevoke(
 	}
 	key := k.(string)
 
-	if err = b.exo.RevokeIAMAccessKey(
-		exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(config.APIEnvironment, config.Zone)),
-		config.Zone,
-		&egoscale.IAMAccessKey{Key: &key},
-	); err != nil {
+	ectx := exoapi.WithEndpoint(ctx, exoapi.NewReqEndpoint(config.APIEnvironment, config.Zone))
+	if err = b.exo.RevokeIAMAccessKey(ectx, config.Zone, &egoscale.IAMAccessKey{Key: &key}); err != nil {
 		return nil, fmt.Errorf("unable to revoke the API key: %w", err)
 	}
+
+	b.Logger().Info("IAM key revoked", "key", key, "lease_id", req.Secret.LeaseID)
 
 	return nil, nil
 }


### PR DESCRIPTION
This fixes an issue that makes the agent's refresh grace period unpredictable and too short.

[Vault agent calculates a grace period of 10 to 20% of the lease TTL](https://github.com/hashicorp/vault/blob/fcbe948b2542a13ee8036ad07dd8ebf8554f56cb/api/lifetime_watcher.go#L376-L391), once we enter the grace period, [the agent stops renewing the lease](https://github.com/hashicorp/vault/blob/fcbe948b2542a13ee8036ad07dd8ebf8554f56cb/api/lifetime_watcher.go#L363:L365) and fetches a new one. This gives the workload time to complete ongoing operations before loading the new secret.

[After each renew, if the lease was extended, vault agent will recalculate the grace period](https://github.com/hashicorp/vault/blob/fcbe948b2542a13ee8036ad07dd8ebf8554f56cb/api/lifetime_watcher.go#L347:L349) based on the new TTL. [If the new TTL is above the Max TTL, the value is capped](https://github.com/hashicorp/vault/blob/fcbe948b2542a13ee8036ad07dd8ebf8554f56cb/sdk/framework/lease.go#L100:L105), reducing the grace period to an unpredictable amount of time.

To make sure it will calculate the refresh grace period based on a full TTL value, we extend the lease only if the TTL is not capped by max_ttl