### PR TITLE
go.mk: remove submodule and initialize through make

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
 
       - uses: ./go.mk/.github/actions/pre-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
         shell: bash
 
       - name: Import GPG key

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/go.mk
 dist/
 bin/
 /release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "go.mk"]
-	path = go.mk
-	url = https://github.com/exoscale/go.mk.git

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,43 @@
+GO_MK_REF := v1.0.0
+
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
+ifndef MAKE_RESTARTS
+# This section will be processed the first time that make reads this file.
+
+# This causes make to re-read the Makefile and all included
+# makefiles after go.mk has been cloned.
+Makefile:
+	@touch Makefile
+endif
+
+.PHONY: go.mk
+.ONESHELL:
+go.mk:
+	@if [ ! -d "go.mk" ]; then
+		git clone https://github.com/exoscale/go.mk.git
+	fi
+	@cd go.mk
+	@if ! git show-ref --quiet --verify "refs/heads/${GO_MK_REF}"; then
+		git fetch
+	fi
+	@if ! git show-ref --quiet --verify "refs/tags/${GO_MK_REF}"; then
+		git fetch --tags
+	fi
+	git checkout --quiet ${GO_MK_REF}
+
 PACKAGE := github.com/exoscale/vault-plugin-secrets-exoscale
 PROJECT_URL := https://$(PACKAGE)
 GO_MAIN_PKG_PATH := ./cmd/vault-plugin-secrets-exoscale
 
 
+go.mk/init.mk:
 include go.mk/init.mk
 
 GO_LD_FLAGS := -ldflags "-s -w -X $(PACKAGE)/version.Version=${VERSION} -X $(PACKAGE)/version.Commit=${GIT_REVISION}"
 
+go.mk/public.mk:
 include go.mk/public.mk
 
 ifeq ($(VERSION), dev)


### PR DESCRIPTION
# Testing
```shell
❯ make build
Cloning into 'go.mk'...
remote: Enumerating objects: 311, done.
remote: Counting objects: 100% (197/197), done.
remote: Compressing objects: 100% (95/95), done.
remote: Total 311 (delta 132), reused 138 (delta 93), pack-reused 114
Receiving objects: 100% (311/311), 62.32 KiB | 3.89 MiB/s, done.
Resolving deltas: 100% (175/175), done.
mkdir -p '/home/sauterp/src/github.com/exoscale/vault-plugin-secrets-exoscale/bin'
'/home/sauterp/bin/go' build \
   \
  -ldflags "-s -w -X github.com/exoscale/vault-plugin-secrets-exoscale/version.Version=dev -X github.com/exoscale/vault-plugin-secrets-exoscale/version.Commit=0ee9199" \
   \
  -o '/home/sauterp/src/github.com/exoscale/vault-plugin-secrets-exoscale/bin/' \
  './cmd/vault-plugin-secrets-exoscale'
```